### PR TITLE
Reintroduce MACos, checkout install and don't use curl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu]
+        os: [ubuntu, macos]
         lfc: [stable, nightly]
         lingo: [stable, 0.2.0]
     steps:

--- a/action.yml
+++ b/action.yml
@@ -18,13 +18,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Check OS
-      run: |
-        if [ "$(uname)" = "Darwin" ]; then
-          echo "macOS is not supported."
-          exit 1
-        fi
-      shell: bash
     - name: Install rust
       uses: dtolnay/rust-toolchain@stable
     - name: Install java
@@ -32,9 +25,21 @@ runs:
       with:
         distribution: 'temurin'
         java-version: '17'
-    - name: Install LFC
+    - name: Checkout LF Install Script repo
+      uses: actions/checkout@v4
+      with:
+        repository: 'lf-lang/installation'
+        path: 'tmp/installation'
+    - name: Install LFC (linux)
+      if: runner.os == 'Linux'
       run: |
-        curl -Ls https://install.lf-lang.org | bash -s cli ${{ inputs.lfc-version }}
+        bash ./tmp/installation/install.sh cli ${{ inputs.lfc-version }}
+      shell: bash
+    - name: Install LFC (macOS)
+      if: runner.os == 'macOS'
+      run: |
+        bash ./tmp/installation/install.sh cli ${{ inputs.lfc-version }} --prefix=$HOME/.local && break
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       shell: bash
     - name: Install lingo
       run: |


### PR DESCRIPTION
After some investigation on the CI runner, a likely potential reason that macos CI jobs fail is that GitHub will rate-limit curl scripts if the user is unauthenticated which the CI clusters are. As eventually we use the script in `lf-lang/installation` it might be a better idea to not use curl and get rate-limited but use checkout directly. This also reduces the dependency of `lf-lang.org` behaving correctly.
    
MacOS CI is also reintroduced in this commit.

I'm not 100% sure if this will work, so please allow me to run them in my repo for a few times before it merges